### PR TITLE
Feature: add `set_state` method to load data from the client into the remote session

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,10 @@
+# Contributors
+
+## Special thanks for all the people who have helped this project so far:
+
+* [Simon Mathis](https://github.com/Croydon-Brixton)
+* [Martin Buttenschön](https://github.com/maabuu)
+
+## I would like to join this list. How can I help the project?
+
+We always welcome contributions to improve the project. Please have a look at the current github issues for information on where help could be needed.

--- a/src/pymol_remote/server.py
+++ b/src/pymol_remote/server.py
@@ -85,7 +85,8 @@ def _get_local_ip() -> str:
 
     Note:
         This method may not work in all network configurations, especially in complex
-        or restricted network environments.
+        or restricted network environments. For more information on how to find out 
+        your local IP address, see e.g. https://www.avg.com/en/signal/find-ip-address
     """
     try:
         # Create a socket and connect to an external server
@@ -128,12 +129,19 @@ def get_state(
             Defaults to "all".
         - state (int, optional): The state of the molecule to include in the output.
             Defaults to `-1`, which means the current state. If state is 0, then
-            a multi-state output file is written.
+            a multi-state output file is written. If you have more than one state, 
+            this produces a multi-state PDB/CIF/etc file.
+            NOTE: If the file extension is ".pse" (PyMOL Session), the complete PyMOL 
+            state is always saved to the file (the selection and state parameters are 
+            thus ignored).
         - format (str, optional): The format of the file to save. Defaults to "pdb".
             Supported formats: "pdb", "sdf", "mol", "png", "cif", "pkl", "pse"
 
     Returns:
         str | bytes: The PDB string or binary file content.
+
+    References:
+     - https://pymolwiki.org/index.php/Save
     """
     _ALLOWED_TEXT_FORMATS = ("pdb", "cif", "mol", "sdf")
     _ALLOWED_BINARY_FORMATS = ("png", "pkl", "pse")
@@ -145,7 +153,7 @@ def get_state(
     # Create a temporary file to write to
     # (pymol does not appear to support writing to in-memory buffers)
     with tempfile.NamedTemporaryFile(
-        delete=False, suffix=f".{format}"
+        delete=True, suffix=f".{format}"
     ) as temp_pdb_file:
         pymol_cmd.save(temp_pdb_file.name, selection, state, format)
 
@@ -172,16 +180,21 @@ def set_state(
         - object (str, optional): The name of the object to load the state into.
             Defaults to "" (the current object).
         - state (int, optional): The state number to load the information into.
-            Defaults to 0.
+            State 0 means to append. Defaults to 0. 
         - format (str, optional): The format of the buffer. Defaults to "pse".
             Supports all PyMOL supported formats: https://pymolwiki.org/index.php/Load
 
     Returns:
         None
+
+    References:
+     - https://pymolwiki.org/index.php/Load
     """
     # Create a temporary file to write to
     # (pymol does not appear to support loading from in-memory buffers)
-    with tempfile.NamedTemporaryFile(delete=True) as temp_pdb_file:
+    with tempfile.NamedTemporaryFile(
+        delete=True, suffix=f".{format}"
+    ) as temp_pdb_file:
         if isinstance(buffer, str):
             with open(temp_pdb_file.name, "w") as file:
                 file.write(buffer)
@@ -263,7 +276,7 @@ def launch_server(
         The server will attempt to bind to the first available port in the range
         [port, port + n_ports_to_try - 1]. If successful, it prints the host and port information.
 
-    Reference:
+    References:
         - https://github.com/schrodinger/pymol-open-source/blob/9d3061ca58d8b69d7dad74a68fc13fe81af0ff8e/modules/pymol/rpc.py
         - https://pymolwiki.org/index.php/XML-RPC_server
     """

--- a/src/pymol_remote/server.py
+++ b/src/pymol_remote/server.py
@@ -313,6 +313,9 @@ def launch_server(
         _GLOBAL_PYMOL_XMLRPC_SERVER.register_function_with_kwargs(
             get_state, "get_state"
         )
+        _GLOBAL_PYMOL_XMLRPC_SERVER.register_function_with_kwargs(
+            set_state, "set_state"
+        )
         _GLOBAL_PYMOL_XMLRPC_SERVER.register_function_with_kwargs(help, "help")
         _GLOBAL_PYMOL_XMLRPC_SERVER.register_introspection_functions()
         server_thread = threading.Thread(

--- a/src/pymol_remote/server.py
+++ b/src/pymol_remote/server.py
@@ -130,12 +130,12 @@ def get_state(
             Defaults to `-1`, which means the current state. If state is 0, then
             a multi-state output file is written.
         - format (str, optional): The format of the file to save. Defaults to "pdb".
-            Supported formats: "pdb", "png", "cif", "pkl", "pse"
+            Supported formats: "pdb", "sdf", "mol", "png", "cif", "pkl", "pse"
 
     Returns:
         str | bytes: The PDB string or binary file content.
     """
-    _ALLOWED_TEXT_FORMATS = ("pdb", "cif")
+    _ALLOWED_TEXT_FORMATS = ("pdb", "cif", "mol", "sdf")
     _ALLOWED_BINARY_FORMATS = ("png", "pkl", "pse")
     if format not in _ALLOWED_TEXT_FORMATS + _ALLOWED_BINARY_FORMATS:
         raise ValueError(

--- a/src/pymol_remote/server.py
+++ b/src/pymol_remote/server.py
@@ -158,6 +158,39 @@ def get_state(
     return buffer
 
 
+def set_state(
+    buffer: str | bytes, object: str = "", state: int = 0, format: str = "pse"
+) -> None:
+    """Set the state of the PyMOL session using the provided buffer.
+
+    This function sets the state of the PyMOL session using the provided buffer,
+    which contains the state information in the appropriate format (e.g. pse bytes or
+    pdb string).
+
+    Args:
+        - buffer (str | bytes): The buffer containing the state information to load.
+        - object (str, optional): The name of the object to load the state into.
+            Defaults to "" (the current object).
+        - state (int, optional): The state number to load the information into.
+            Defaults to 0.
+        - format (str, optional): The format of the buffer. Defaults to "pse".
+            Supports all PyMOL supported formats: https://pymolwiki.org/index.php/Load
+
+    Returns:
+        None
+    """
+    # Create a temporary file to write to
+    # (pymol does not appear to support loading from in-memory buffers)
+    with tempfile.NamedTemporaryFile(delete=True) as temp_pdb_file:
+        if isinstance(buffer, str):
+            with open(temp_pdb_file.name, "w") as file:
+                file.write(buffer)
+        else:
+            with open(temp_pdb_file.name, "wb") as file:
+                file.write(buffer)
+        pymol_cmd.load(temp_pdb_file.name, object, state, format)
+
+
 def help(command: str | None = None) -> str:
     """Provide help information for PyMOL XML-RPC server functions.
 

--- a/src/pymol_remote/server.py
+++ b/src/pymol_remote/server.py
@@ -130,13 +130,13 @@ def get_state(
             Defaults to `-1`, which means the current state. If state is 0, then
             a multi-state output file is written.
         - format (str, optional): The format of the file to save. Defaults to "pdb".
-            Supported formats: "pdb", "mol", "png", "cif"
+            Supported formats: "pdb", "png", "cif", "pkl", "pse"
 
     Returns:
         str | bytes: The PDB string or binary file content.
     """
     _ALLOWED_TEXT_FORMATS = ("pdb", "cif")
-    _ALLOWED_BINARY_FORMATS = ("png", "pkl")
+    _ALLOWED_BINARY_FORMATS = ("png", "pkl", "pse")
     if format not in _ALLOWED_TEXT_FORMATS + _ALLOWED_BINARY_FORMATS:
         raise ValueError(
             f"Format {format} not supported. Please use one of the following: {_ALLOWED_TEXT_FORMATS + _ALLOWED_BINARY_FORMATS}"


### PR DESCRIPTION
Changes:
- Adds the method `set_state` to load data from the client into the remote session. This is reciprocal to the existing `get_state` method. 
- Adds `.pse` as a supported format to the `get_state` method. This format can store the complete PyMOL state https://pymolwiki.org/index.php/Save
